### PR TITLE
v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.6
+
+- Added `AsyncEventPulling.pull`.
+- Add `AsyncEventError`.
+- `AsyncEventStorageRemote`:
+  - Added field `retryInterval`.
+  - Retries of failed requests.
+
 ## 1.0.5
 
 - `AsyncEventChannel`:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_events
 description: A portable asynchronous event hub supporting multiple storage types
-version: 1.0.5
+version: 1.0.6
 homepage: https://github.com/gmpassos/async_events
 
 environment:


### PR DESCRIPTION
- Added `AsyncEventPulling.pull`.
- Add `AsyncEventError`.
- `AsyncEventStorageRemote`:
  - Added field `retryInterval`.
  - Retries of failed requests.