### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.2.0
+
+- `AsyncEventID`: added `tryParse`.
+
+- `AsyncEventHub`: added `purge`.
+
+- `AsyncEventChannel`:
+  - Added `purge`.
+  - `submit`: added parameter `time`.
+
+- `AsyncEventStorage`:
+  - Rename `purge` to `purgeEpochs`.
+  - Added `purgeEvents`.
+
+- Fix channel initial synchronization when using `limit`.
+
 ## 1.1.1
 
 - `AsyncEventChannel`, `AsyncEventStorage`:

--- a/lib/src/reflection/async_events_base.g.dart
+++ b/lib/src/reflection/async_events_base.g.dart
@@ -911,7 +911,10 @@ class AsyncEventID$reflection extends ClassReflection<AsyncEventID>
     }
   }
 
-  static const List<String> _staticMethodsNames = const <String>['boot'];
+  static const List<String> _staticMethodsNames = const <String>[
+    'boot',
+    'tryParse'
+  ];
 
   @override
   List<String> get staticMethodsNames => _staticMethodsNames;
@@ -945,6 +948,18 @@ class AsyncEventID$reflection extends ClassReflection<AsyncEventID>
             false,
             () => AsyncEventID.boot,
             null,
+            null,
+            null,
+            null);
+      case 'tryparse':
+        return StaticMethodReflection<AsyncEventID, AsyncEventID?>(
+            this,
+            AsyncEventID,
+            'tryParse',
+            __TR<AsyncEventID>(AsyncEventID),
+            true,
+            () => AsyncEventID.tryParse,
+            const <__PR>[__PR(__TR.tString, 's', true, true)],
             null,
             null,
             null);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_events
 description: A portable asynchronous event hub supporting multiple storage types
-version: 1.1.1
+version: 1.2.0
 homepage: https://github.com/gmpassos/async_events
 
 environment:

--- a/test/async_events_test.dart
+++ b/test/async_events_test.dart
@@ -14,6 +14,55 @@ void main() {
       .listen((event) => print('${DateTime.now()}\t$event'));
 
   group('AsyncEvent', () {
+    test('insertSorted', () async {
+      {
+        var l0 = <AsyncEvent>[];
+
+        l0.insertSorted(
+            AsyncEvent('a', AsyncEventID(0, 2), DateTime.now(), 't', {'n': 2}));
+
+        l0.insertSorted(
+            AsyncEvent('a', AsyncEventID(0, 3), DateTime.now(), 't', {'n': 3}));
+
+        expect(l0.map((e) => e.id.toString()), equals(['0#2', '0#3']));
+      }
+
+      {
+        var l0 = <AsyncEvent>[];
+
+        l0.insertSorted(
+            AsyncEvent('a', AsyncEventID(0, 2), DateTime.now(), 't', {'n': 2}));
+
+        l0.insertSorted(
+            AsyncEvent('a', AsyncEventID(0, 1), DateTime.now(), 't', {'n': 1}));
+
+        expect(l0.map((e) => e.id.toString()), equals(['0#1', '0#2']));
+      }
+
+      var l1 = <AsyncEvent>[
+        AsyncEvent('a', AsyncEventID(0, 0), DateTime.now(), 'new_epoch', {}),
+        AsyncEvent('a', AsyncEventID(0, 1), DateTime.now(), 't', {'n': 1}),
+        AsyncEvent('a', AsyncEventID(0, 2), DateTime.now(), 't', {'n': 2}),
+        AsyncEvent('a', AsyncEventID(0, 3), DateTime.now(), 't', {'n': 3}),
+      ];
+
+      l1.insertSorted(
+          AsyncEvent('a', AsyncEventID(0, 4), DateTime.now(), 't', {'n': 4}));
+
+      expect(l1.map((e) => e.id.toString()),
+          equals(['0#0', '0#1', '0#2', '0#3', '0#4']));
+
+      var l2 = l1.sublist(2);
+
+      expect(l2.map((e) => e.id.toString()), equals(['0#2', '0#3', '0#4']));
+
+      l2.insertSorted(
+          AsyncEvent('a', AsyncEventID(0, 1), DateTime.now(), 't', {'n': 1}));
+
+      expect(
+          l2.map((e) => e.id.toString()), equals(['0#1', '0#2', '0#3', '0#4']));
+    });
+
     test('json', () async {
       var now = DateTime.now();
 

--- a/test/async_events_test.dart
+++ b/test/async_events_test.dart
@@ -232,8 +232,9 @@ class _MyAsyncEventStorageServer with AsyncEventStorageAsJSON {
 
   @override
   Future<Map<String, dynamic>?> newEvent(
-          String channelName, String type, Map<String, dynamic> payload) =>
-      super.newEvent(channelName, type, payload).asFutureDelayed;
+          String channelName, String type, Map<String, dynamic> payload,
+          {DateTime? time}) =>
+      super.newEvent(channelName, type, payload, time: time).asFutureDelayed;
 
   final Map<String, int> _fetchRequestCounter = <String, int>{};
 
@@ -262,7 +263,15 @@ class _MyAsyncEventStorageServer with AsyncEventStorageAsJSON {
       super.last(channelName).asFutureDelayed;
 
   @override
-  Future<int> purge(int untilEpoch) => super.purge(untilEpoch).asFutureDelayed;
+  Future<int> purgeEpochs(int untilEpoch) =>
+      super.purgeEpochs(untilEpoch).asFutureDelayed;
+
+  @override
+  Future<int> purgeEvents(String channelName,
+          {AsyncEventID? untilID, DateTime? before, bool all = false}) =>
+      super
+          .purgeEvents(channelName, untilID: untilID, before: before, all: all)
+          .asFutureDelayed;
 
   @override
   String toString() {

--- a/test/async_events_test.dart
+++ b/test/async_events_test.dart
@@ -233,6 +233,26 @@ Future<void> _doTestBasic(
 
   expect(await c1.purge(untilID: eventC1_2.id), equals(2));
 
+  expect(await eventPulling.pull(), equals(0));
+
+  expect(eventPulling.isPulling, isFalse);
+
+  expect(c1Events.map((e) => '${e.id}${e.payload}'),
+      equals(['0#1{name: t1}', '0#2{name: t4}', '1#1{name: t5}']));
+
+  expect(await c1.submit('t', {'name': 't5.2'}), isNotNull);
+
+  expect(await eventPulling.waitPulling(), isTrue);
+
+  expect(
+      c1Events.map((e) => '${e.id}${e.payload}'),
+      equals([
+        '0#1{name: t1}',
+        '0#2{name: t4}',
+        '1#1{name: t5}',
+        '1#2{name: t5.2}'
+      ]));
+
   expect(
       (await c1.fetch(AsyncEventID.any()))
           .map((e) => '${e.id}${e.payload}')
@@ -241,7 +261,8 @@ Future<void> _doTestBasic(
         '0#0{nextID: 0#2}',
         '0#2{name: t4}',
         '1#0{previousID: 0#2}',
-        '1#1{name: t5}'
+        '1#1{name: t5}',
+        '1#2{name: t5.2}'
       ]));
 
   var submitAsync = c1.submit('t', {'name': 't6'});

--- a/test/async_events_test.dart
+++ b/test/async_events_test.dart
@@ -163,6 +163,31 @@ Future<void> _doTestBasic(
   expect((await c1.fetch(eventC1_2.id, limit: 1)).where((e) => e.type == 't'),
       equals([eventC1_3]));
 
+  expect(
+      (await c1.fetch(AsyncEventID.any()))
+          .map((e) => '${e.id}${e.payload}')
+          .toList(),
+      equals([
+        '0#0{}',
+        '0#1{name: t1}',
+        '0#2{name: t4}',
+        '1#0{previousID: 0#2}',
+        '1#1{name: t5}'
+      ]));
+
+  expect(await c1.purge(untilID: eventC1_2.id), equals(2));
+
+  expect(
+      (await c1.fetch(AsyncEventID.any()))
+          .map((e) => '${e.id}${e.payload}')
+          .toList(),
+      equals([
+        '0#0{nextID: 0#2}',
+        '0#2{name: t4}',
+        '1#0{previousID: 0#2}',
+        '1#1{name: t5}'
+      ]));
+
   var submitAsync = c1.submit('t', {'name': 't6'});
 
   eventPulling.cancelChannelCalls();

--- a/test/async_events_test.dart
+++ b/test/async_events_test.dart
@@ -47,20 +47,27 @@ void main() {
       ];
 
       l1.insertSorted(
+          AsyncEvent('a', AsyncEventID(0, 5), DateTime.now(), 't', {'n': 5}));
+
+      expect(l1.map((e) => e.id.toString()),
+          equals(['0#0', '0#1', '0#2', '0#3', '0#5']));
+
+      l1.insertSorted(
           AsyncEvent('a', AsyncEventID(0, 4), DateTime.now(), 't', {'n': 4}));
 
       expect(l1.map((e) => e.id.toString()),
-          equals(['0#0', '0#1', '0#2', '0#3', '0#4']));
+          equals(['0#0', '0#1', '0#2', '0#3', '0#4', '0#5']));
 
       var l2 = l1.sublist(2);
 
-      expect(l2.map((e) => e.id.toString()), equals(['0#2', '0#3', '0#4']));
+      expect(
+          l2.map((e) => e.id.toString()), equals(['0#2', '0#3', '0#4', '0#5']));
 
       l2.insertSorted(
           AsyncEvent('a', AsyncEventID(0, 1), DateTime.now(), 't', {'n': 1}));
 
-      expect(
-          l2.map((e) => e.id.toString()), equals(['0#1', '0#2', '0#3', '0#4']));
+      expect(l2.map((e) => e.id.toString()),
+          equals(['0#1', '0#2', '0#3', '0#4', '0#5']));
     });
 
     test('json', () async {


### PR DESCRIPTION
- `AsyncEventID`: added `tryParse`.

- `AsyncEventHub`: added `purge`.

- `AsyncEventChannel`:
  - Added `purge`.
  - `submit`: added parameter `time`.

- `AsyncEventStorage`:
  - Rename `purge` to `purgeEpochs`.
  - Added `purgeEvents`.

- Fix channel initial synchronization when using `limit`.